### PR TITLE
Add shutdown command; refresh containers list

### DIFF
--- a/lwp.py
+++ b/lwp.py
@@ -59,25 +59,7 @@ def home():
     home page function
     '''
     if 'logged_in' in session:
-        
-        listx = lxc.listx()
-        containers_all = []
-
-        for status in ['RUNNING', 'FROZEN', 'STOPPED']:
-            containers_by_status = []
-
-            for container in listx[status]:
-                containers_by_status.append({
-                    'name': container,
-                    'memusg': lwp.memory_usage(container),
-                    'settings': lwp.get_container_settings(container)
-                })
-            containers_all.append({
-                        'status' : status.lower(),
-                        'containers' : containers_by_status
-                })
-
-        return render_template('index.html', containers=lxc.ls(), containers_all=containers_all, dist=lwp.check_ubuntu(), templates=lwp.get_templates_list())
+        return render_template('index.html', containers=lxc.ls(), dist=lwp.check_ubuntu(), templates=lwp.get_templates_list())
     return render_template('login.html')
 
 
@@ -640,6 +622,29 @@ def logout():
     return redirect(url_for('login'))
 
 
+@app.route('/_refresh_containers')
+def refresh_containers():
+    if 'logged_in' in session:
+        listx = lxc.listx()
+        containers_all = []
+
+        for status in ['RUNNING', 'FROZEN', 'STOPPED']:
+            containers_by_status = []
+
+            for container in listx[status]:
+                containers_by_status.append({
+                    'name': container,
+                    'memusg': lwp.memory_usage(container),
+                    'settings': lwp.get_container_settings(container)
+                })
+            containers_all.append({
+                        'status' : status.lower(),
+                        'containers' : containers_by_status
+                })
+
+        return render_template('containers.html', containers_all=containers_all)
+
+    
 @app.route('/_refresh_cpu_host')
 def refresh_cpu_host():
     if 'logged_in' in session:

--- a/lwp.py
+++ b/lwp.py
@@ -429,7 +429,7 @@ def action():
                     if lxc.shutdown(name) == 0:
                         flash(u'Container %s shutdown initiated.' % name, 'success')
                     else:
-                        flash(u'Unable to stop %s!' % name, 'error')
+                        flash(u'Unable to shutdown %s!' % name, 'error')
                 except lxc.ContainerNotRunning:
                     flash(u'Container %s is already stopped!' % name, 'error')
             elif action == 'freeze':

--- a/lwp.py
+++ b/lwp.py
@@ -424,6 +424,14 @@ def action():
                         flash(u'Unable to stop %s!' % name, 'error')
                 except lxc.ContainerNotRunning:
                     flash(u'Container %s is already stopped!' % name, 'error')
+            elif action == 'shutdown':
+                try:
+                    if lxc.shutdown(name) == 0:
+                        flash(u'Container %s shutdown initiated.' % name, 'success')
+                    else:
+                        flash(u'Unable to stop %s!' % name, 'error')
+                except lxc.ContainerNotRunning:
+                    flash(u'Container %s is already stopped!' % name, 'error')
             elif action == 'freeze':
                 try:
                     if lxc.freeze(name) == 0:

--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -150,7 +150,16 @@ def stop(container):
     if container in stopped(): raise ContainerNotRunning('Container {} is not running!'.format(container))
     return _run('lxc-stop -n {}'.format(container))
 
+    
+def shutdown(container):
+    '''
+    Stops a container nicely
+    '''
+    if not exists(container): raise ContainerDoesntExists('Container {} does not exists!'.format(container))
+    if container in stopped(): raise ContainerNotRunning('Container {} is not running!'.format(container))
+    return _run('lxc-shutdown -n {}'.format(container))
 
+    
 def freeze(container):
     '''
     Freezes a container

--- a/templates/containers.html
+++ b/templates/containers.html
@@ -1,0 +1,46 @@
+{% set td = {'running':'success','frozen':'info','stopped':'important'} %}
+{% set tr = {'running':'success','frozen':'info','stopped':'error'} %}
+{% set disabled = {'running':'success','frozen':'info','stopped':'important'} %}
+
+{% macro memory_color(value) -%}{% if value != 0 %}{% if 0 <= value <= 511 %}success{% elif 512 <= value < 980 %}warning{% else %}important{% endif %}{% endif %}{%- endmacro %}
+{% macro render_memory_wrapper(value) -%}
+	{% if value != 0 %}<span class="label label-{{ memory_color(value) }}">{{ value }} MB</span>{% endif %}
+{%- endmacro %}
+
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			<th>Status</th>
+			<th>Name</th>
+			<th>Hostname</th>
+			<th>IP Address</th>
+			<th>Mem. usage</th>
+			<th>Actions</th>
+		</tr>
+	</thead>	
+	{% for status in containers_all %}
+		<tbody>
+			{% for container in status.containers %}
+				<tr class="{{ tr[status.status] }}">
+					{% if loop.first %}<td rowspan="{{ status.containers|count }}"><span class="label label-{{ td[status.status] }}">{{ status.status|capitalize }}</span></td>{% endif %}
+					<td><a href="{{ url_for('edit',container=container.name) }}" title="Click to edit {{container.name}}">{{container.name}}</a></td>
+					<td>{{container.settings.utsname}}</td>
+					<td>{% if container.settings.flags == 'up' %}{% if container.settings.ipv4 != '' %}{{container.settings.ipv4}}{% else %}Undefined{% endif %}{% elif container.settings.flags == 'down' %}Link Down{% endif %}</td>
+					<td id="{{container.name}}">{{ render_memory_wrapper(container.memusg) }}</td>
+					<td>
+						<div class="btn-toolbar" style="margin:8px 0;">
+							<div class="btn-group">
+								{% set start_action = {'stopped':'start','frozen':'unfreeze'} %}
+								<a class="btn btn-small{% if status.status == 'running' %} disabled{% endif %}"{% if status.status == 'stopped' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action=start_action[status.status], token=session.token) }}"{% endif %}><i class="icon-play"></i> Start</a>
+								<a class="btn btn-small{% if status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action='shutdown', token=session.token) }}"{% endif %}><i class="icon-eject"></i> Shutdown</a>
+								<a class="btn btn-small{% if status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action='stop', token=session.token) }}"{% endif %}><i class="icon-stop"></i> Stop</a>
+								<a class="btn btn-small{% if status.status == 'frozen' or status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' %} href="{{ url_for('action', name=container.name, action='freeze', token=session.token) }}"{% endif %}><i class="icon-pause"></i> Freeze</a>
+							</div>
+							{% if session.su == 'Yes' %}<a class="pull-right close destroy" data-container-name="{{container.name}}" style="margin-top:4px;"><i class="icon-remove-sign"></i></a>{% endif %}
+						</div>
+					</td>
+				</tr>
+			{% endfor %}
+		</tbody>
+	{% endfor %}
+</table>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,3 @@
-{% set td = {'running':'success','frozen':'info','stopped':'important'} %}
-{% set tr = {'running':'success','frozen':'info','stopped':'error'} %}
-{% set disabled = {'running':'success','frozen':'info','stopped':'important'} %}
 {% extends "layout.html" %}
 {% block title %}Overview{% endblock %}
 {% block content %}
@@ -35,43 +32,8 @@
 		</div>
 		<a href="http://lxc-webpanel.github.io/" target="_blank"><span class="label label-info hide" id="version" style="position:relative; float:right; bottom:0; margin:-20px -23px 0 0;"><i class="icon-info-sign icon-white"></i> New version is out ! (<span id="vernumber"></span>)</span></a>
 	</div>
-	<table class="table table-bordered">
-		<thead>
-			<tr>
-				<th>Status</th>
-				<th>Name</th>
-				<th>Hostname</th>
-				<th>IP Address</th>
-				<th>Mem. usage</th>
-				<th>Actions</th>
-			</tr>
-		</thead>	
-		{% for status in containers_all %}
-			<tbody>
-				{% for container in status.containers %}
-					<tr class="{{ tr[status.status] }}">
-						{% if loop.first %}<td rowspan="{{ status.containers|count }}"><span class="label label-{{ td[status.status] }}">{{ status.status|capitalize }}</span></td>{% endif %}
-						<td><a href="{{ url_for('edit',container=container.name) }}" title="Click to edit {{container.name}}">{{container.name}}</a></td>
-						<td>{{container.settings.utsname}}</td>
-						<td>{% if container.settings.flags == 'up' %}{% if container.settings.ipv4 != '' %}{{container.settings.ipv4}}{% else %}Undefined{% endif %}{% elif container.settings.flags == 'down' %}Link Down{% endif %}</td>
-						<td id="{{container.name}}">{{ render_memory_wrapper(container.memusg) }}</td>
-						<td>
-							<div class="btn-toolbar" style="margin:8px 0;">
-								<div class="btn-group">
-									{% set start_action = {'stopped':'start','frozen':'unfreeze'} %}
-									<a class="btn btn-small{% if status.status == 'running' %} disabled{% endif %}"{% if status.status == 'stopped' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action=start_action[status.status], token=session.token) }}"{% endif %}><i class="icon-play"></i> Start</a>
-									<a class="btn btn-small{% if status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action='shutdown', token=session.token) }}"{% endif %}><i class="icon-eject"></i> Shutdown</a>
-									<a class="btn btn-small{% if status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action='stop', token=session.token) }}"{% endif %}><i class="icon-stop"></i> Stop</a>
-									<a class="btn btn-small{% if status.status == 'frozen' or status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' %} href="{{ url_for('action', name=container.name, action='freeze', token=session.token) }}"{% endif %}><i class="icon-pause"></i> Freeze</a>
-								</div>
-								{% if session.su == 'Yes' %}<a class="pull-right close destroy" data-container-name="{{container.name}}" style="margin-top:4px;"><i class="icon-remove-sign"></i></a>{% endif %}
-							</div>
-						</td>
-					</tr>
-				{% endfor %}
-			</tbody>
-		{% endfor %}
-	</table>
+	<div id="containers_placeholder">
+	</div>
 </div>
 {% if session.su == 'Yes' %}
 	{% include "includes/modal_reboot.html" %}
@@ -84,11 +46,6 @@
 {% endif %}
 
 {% endblock %}
-
-{% macro memory_color(value) -%}{% if value != 0 %}{% if 0 <= value <= 511 %}success{% elif 512 <= value < 980 %}warning{% else %}important{% endif %}{% endif %}{%- endmacro %}
-{% macro render_memory_wrapper(value) -%}
-	{% if value != 0 %}<span class="label label-{{ memory_color(value) }}">{{ value }} MB</span>{% endif %}
-{%- endmacro %}
 
 {% block script %}
 <script src="/static/js/bootstrapSwitch.js"></script>
@@ -121,27 +78,16 @@
 				});
 			}
 
-			function refreshMemoryContainers(){
-				$.getJSON($SCRIPT_ROOT + '/_refresh_memory_containers', function(data) {
-					data = data.data;
-					for (i in data) {
-						var el = $('#'+data[i].name+' span');
-						el.text(data[i].memusg+' MB');
-						el[0].className = el[0].className.replace(/label\-(success|warning|important)/g,'label-'+memory_color(data[i].memusg));
-					}
+			function refreshContainerList(){
+				$.get($SCRIPT_ROOT + '/_refresh_containers', function(data) {
+					$('#containers_placeholder').html(data);
+					$(".destroy").on('click',function(e){
+						$(".destroy-link").attr('href',"/action?action=destroy&token={{ session.token }}&name="+ $(this).data('container-name'));
+						$('#destroy').modal('show');
+					});
 				});
 			}
-
-			function memory_color(value){
-				if(value != 0)
-					if ('0' <= value && value <= '512')
-						 return 'success';
-					else if ('512' <= value && value < '1024')
-						return 'warning';
-					else
-						return 'important';
-			}
-
+			
 			function check_version(){
 				$.getJSON($SCRIPT_ROOT + '/_check_version', function(data) {
 					if (data.latest > data.current) {
@@ -159,11 +105,11 @@
 
 			function refresh(){
 				$('#home-load').fadeIn();
+				refreshContainerList();
 				refreshMemoryHost();
 				refreshCPUHost();
 				refreshDiskHost();
 				refreshUptimeHost();
-				refreshMemoryContainers();
 				$('#home-load').fadeOut();
 			}
 
@@ -175,14 +121,6 @@
 			});
 
 			{% if session.su == 'Yes' %}$(document).ready(function(){
-
-				var token = '{{ session.token }}';
-
-				$(".destroy").on('click',function(e){
-					$(".destroy-link").attr('href',"/action?action=destroy&token="+ token +"&name="+ $(this).data('container-name'));
-					$('#destroy').modal('show');
-				});
-
 				// Create CT
 				$('#advancedcreate').click(function(e){ e.preventDefault(); $('#advancedcreatediv').slideToggle(); });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,6 +60,7 @@
 								<div class="btn-group">
 									{% set start_action = {'stopped':'start','frozen':'unfreeze'} %}
 									<a class="btn btn-small{% if status.status == 'running' %} disabled{% endif %}"{% if status.status == 'stopped' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action=start_action[status.status], token=session.token) }}"{% endif %}><i class="icon-play"></i> Start</a>
+									<a class="btn btn-small{% if status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action='shutdown', token=session.token) }}"{% endif %}><i class="icon-eject"></i> Shutdown</a>
 									<a class="btn btn-small{% if status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' or status.status == 'frozen' %} href="{{ url_for('action', name=container.name, action='stop', token=session.token) }}"{% endif %}><i class="icon-stop"></i> Stop</a>
 									<a class="btn btn-small{% if status.status == 'frozen' or status.status == 'stopped' %} disabled{% endif %}"{% if status.status == 'running' %} href="{{ url_for('action', name=container.name, action='freeze', token=session.token) }}"{% endif %}><i class="icon-pause"></i> Freeze</a>
 								</div>


### PR DESCRIPTION
The "stop" command on the main page kills containers without allowing services inside them to clean up after themselves. This patch adds a "shutdown" command which uses lxc-shutdown to stop containers. 

Since the shutdown may take some time, the containers list would still show the container as "running", until you manually refreshed the page. The containers list is now periodically refreshed (along with the host memory usage and cpu load). This has the added advantage that any changes that are e.g. performed from the command line will automatically become visible in the web panel.

The patch moves the template code for the containers list to a separate template, which is loaded from `/_refresh_containers` using `$.get`. Handlers for the destroy buttons are added.

(Created a new pull request from a separate branch)
