### PR TITLE
Add error message when cloning a running instance

### DIFF
--- a/lwp.py
+++ b/lwp.py
@@ -575,6 +575,8 @@ def clone_container():
                     out = lxc.clone(orig=orig, new=name, snapshot=snapshot)
                 except lxc.ContainerAlreadyExists:
                     flash(u'The Container %s already exists!' % name, 'error')
+                except lxc.ContainerAlreadyRunning:
+                    flash(u'The Container %s must be stopped before cloning!' % orig, 'error')
                 except subprocess.CalledProcessError:
                     flash(u'Can\'t snapshot a directory', 'error')
 

--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -67,6 +67,7 @@ def clone(orig=None, new=None, snapshot=False):
     '''
     if orig and new:
         if exists(new): raise ContainerAlreadyExists('Container {} already exist!'.format(new))
+        if orig not in stopped(): raise ContainerAlreadyRunning('Cannot clone running container {}!'.format(orig))
 
         command = 'lxc-clone -o {} -n {}'.format(orig, new)
         if snapshot: command += ' -s'


### PR DESCRIPTION
Show a sensible error message when attempting to clone from a running container. Currently the error message shown is "Can't snapshot a directory"
