### PR TITLE
Fixed some minor issues with lxclite

### DIFF
--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -56,7 +56,7 @@ def create(container, template='ubuntu', storage=None, xargs=None):
     command = 'lxc-create -n {}'.format(container)
     command += ' -t {}'.format(template)
     if storage: command += ' -B {}'.format(storage)
-    if xargs: command += ' -- {}'.format(storage)
+    if xargs: command += ' -- {}'.format(xargs)
             
     return _run(command)
 


### PR DESCRIPTION
- 'storage' was being used instead of 'xargs'
- Don't include files in /var/lib/lxc in the container listing - newer versions of LXC dump log files there and show up in the Overview page in LWP
