### PR TITLE
Support unprivileged containers

### DIFF
--- a/lwp/__init__.py
+++ b/lwp/__init__.py
@@ -288,7 +288,12 @@ def get_container_settings(name):
     '''
     returns a dict of all utils settings for a container
     '''
-    filename = '/var/lib/lxc/%s/config' % name
+
+    if os.geteuid():
+        filename = os.path.expanduser('~/.local/share/lxc/%s/config' % name)
+    else:
+        filename = '/var/lib/lxc/%s/config' % name
+
     if not file_exist(filename):
         return False
     config = configparser.SafeConfigParser()
@@ -416,7 +421,12 @@ def push_config_value(key, value, container=None):
             return values
 
     if container:
-        filename = '/var/lib/lxc/%s/config' % container
+        if os.geteuid():
+            filename = os.path.expanduser('~/.local/share/lxc/%s/config' %
+                                          container)
+        else:
+            filename = '/var/lib/lxc/%s/config' % container
+
         save = save_cgroup_devices(filename=filename)
 
         config = configparser.RawConfigParser()

--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -144,7 +144,11 @@ def ls():
     Note: Directory mode for Ubuntu 12/13 compatibility
     '''
 
-    base_path = '/var/lib/lxc'
+    if os.geteuid():
+        base_path = os.path.expanduser("~/.local/share/lxc/")
+    else:
+        base_path = '/var/lib/lxc'
+
     try:
         ct_list = [x for x in os.listdir(base_path)
                    if os.path.isdir(os.path.join(base_path, x))]


### PR DESCRIPTION
This adds basic support for containers sorted in the home directory.

Unfortunately those won't quite work afterwards because their config can not be represented as an ini due to duplicate keys (lxc.include, lxc.cap.drop, lxc.id_map) but the change should still be safe.

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
