### PR TITLE
fix the issue with summary page not displaying the containers. This is b...

### DIFF
--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -123,7 +123,7 @@ def info(container):
         raise ContainerDoesntExists(
             'Container {} does not exist!'.format(container))
 
-    output = _run('lxc-info -qn {}'.format(container),
+    output = _run('lxc-info -qn {}|grep -i "State\|PID"'.format(container),
                   output=True).splitlines()
 
     state = output[0].split()[1]


### PR DESCRIPTION
...ecause

if the containers are running then the output chages for lxc-info and contains
Name as the first line. This should work backwards as well, although not tested.
