### PR TITLE
Fixed directories containing a dot not getting accepted as rootfs directory

### DIFF
--- a/lwp.py
+++ b/lwp.py
@@ -279,7 +279,7 @@ def edit(container=None):
                 flash(u'CPU shares updated for %s!' % container, 'success')
 
             if form['rootfs'] != cfg['rootfs'] and \
-                    re.match('^[a-zA-Z0-9_/\-]+', form['rootfs']):
+                    re.match('^[a-zA-Z0-9_/\-\.]+', form['rootfs']):
                 lwp.push_config_value('lxc.rootfs', form['rootfs'],
                                       container=container)
                 flash(u'Rootfs updated!' % container, 'success')

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -112,7 +112,7 @@
 			<div class="control-group">
 				<label class="control-label" for="inputRootfs">Root FS</label>
 				<div class="controls">
-					<input pattern="[a-zA-Z0-9_/\-]+" type="text" id="inputRootfs" name="rootfs" value="{{ settings.rootfs }}">
+					<input pattern="[a-zA-Z0-9_/\-\.]+" type="text" id="inputRootfs" name="rootfs" value="{{ settings.rootfs }}">
 					<span class="help-inline"><small>(e.g /var/lib/lxc/{{container}}/rootfs)</small></span>
 				</div>
 			</div>


### PR DESCRIPTION
If your rootfs directory contains a dot somewhere you will not be able to edit your container settings.
This is an issue particularly when using unprivileged container since they use $HOME/.local/share/lxc as default storage location.
This fix simply modifies the regex to allow dots. 
