### PR TITLE
- fix apply network settings configuration

### DIFF
--- a/lwp/__init__.py
+++ b/lwp/__init__.py
@@ -261,16 +261,23 @@ def check_version():
     return {'current': current,
             'latest': latest}
 
+def get_net_settings_fname():
+    filename = '/etc/default/lxc-net'
+    if not file_exist(filename):
+        filename = '/etc/default/lxc'
+    if not file_exist(filename):
+        filename = None
+    return filename
+
 
 def get_net_settings():
     '''
     returns a dict of all known settings for LXC networking
     '''
-    filename = '/etc/default/lxc-net'
-    if not file_exist(filename):
-        filename = '/etc/default/lxc'
-    if not file_exist(filename):
+    filename = get_net_settings_fname()
+    if not filename:
         return False
+
     config = configparser.SafeConfigParser()
     cfg = {}
     config.readfp(FakeSection(open(filename)))
@@ -358,10 +365,12 @@ def get_container_settings(name):
     return cfg
 
 
-def push_net_value(key, value, filename='/etc/default/lxc'):
+def push_net_value(key, value):
     '''
     replace a var in the lxc-net config file
     '''
+    filename = get_net_settings_fname()
+
     if filename:
         config = configparser.RawConfigParser()
         config.readfp(FakeSection(open(filename)))


### PR DESCRIPTION
Please review the fix for network settings screen.
Settings are read from /etc/default/lxc-net if exists, or /etc/default/lxc, lxc-net is having a priority over lxc.
From looking at lxc contents is the same relationship, i.e. lxc-net is can override default settings from lxc.

def get_net_settings() - code reflects that relationship
def push_net_value() - does not

It feels like these 2 functions should be symmetric.

so with the current code network changes are saved in to /etc/default/lxc, those changes are not picked up by lxc, since /etc/default/lxc-net overrides them, as well as the screen does not update with new values after hitting apply for the same reason.

Regards,
Alex

