### PR TITLE
Better error reporting on container creation failure

### DIFF
--- a/lwp.py
+++ b/lwp.py
@@ -630,7 +630,7 @@ def action():
                 if session['su'] != 'Yes':
                     return abort(403)
                 try:
-                    lxc.destroy(name):
+                    lxc.destroy(name)
                     flash(u'Container %s destroyed successfully!' % name, 'success')
                 except lxc.ContainerDoesntExists:
                     flash(u'The Container %s does not exists!' % name, 'error')

--- a/lwp.py
+++ b/lwp.py
@@ -103,11 +103,15 @@ def home():
         for status in ['RUNNING', 'FROZEN', 'STOPPED']:
             containers_by_status = []
 
+            running = (status == 'RUNNING')
             for container in listx[status]:
+                settings = lwp.get_container_settings(container)
+                if running:
+                    settings['ipv4'] = lxc.ip_address(container, running) 
                 containers_by_status.append({
                     'name': container,
                     'memusg': lwp.memory_usage(container),
-                    'settings': lwp.get_container_settings(container)
+                    'settings': settings
                 })
             containers_all.append({
                 'status': status.lower(),

--- a/lwp.py
+++ b/lwp.py
@@ -689,7 +689,7 @@ def create_container():
                         flash(u'The Container %s is already created!' % name,
                               'error')
                     except subprocess.CalledProcessError:
-                        flash(u'Error!' % name, 'error')
+                        flash(u'Error creating container %s' % name, 'error')
 
                 elif storage_method == 'directory':
                     directory = request.form['dir']
@@ -708,7 +708,7 @@ def create_container():
                             flash(u'The Container %s is already created!'
                                   % name, 'error')
                         except subprocess.CalledProcessError:
-                            flash(u'Error!' % name, 'error')
+                            flash(u'Error creating container %s' % name, 'error')
 
                 elif storage_method == 'zfs':
                     zfs = request.form['zpoolname']
@@ -722,7 +722,7 @@ def create_container():
                         except lxc.ContainerAlreadyExists:
                             flash(u'The Container %s is already created!' % name, 'error')
                         except subprocess.CalledProcessError:
-                            flash(u'Error!' % name, 'error')
+                            flash(u'Error creating container %s' % name, 'error')
 
                 elif storage_method == 'lvm':
                     lvname = request.form['lvname']
@@ -752,7 +752,7 @@ def create_container():
                         flash(u'The container/logical volume %s is '
                               'already created!' % name, 'error')
                     except subprocess.CalledProcessError:
-                        flash(u'Error!' % name, 'error')
+                        flash(u'Error creating container %s' % name, 'error')
 
                 else:
                     flash(u'Missing parameters to create container!', 'error')

--- a/lwp.py
+++ b/lwp.py
@@ -688,8 +688,8 @@ def create_container():
                     except lxc.ContainerAlreadyExists:
                         flash(u'The Container %s is already created!' % name,
                               'error')
-                    except subprocess.CalledProcessError:
-                        flash(u'Error creating container %s' % name, 'error')
+                    except subprocess.CalledProcessError as e:
+                        flash(u'Error creating container %s: %s' % (name, e.output), 'error')
 
                 elif storage_method == 'directory':
                     directory = request.form['dir']
@@ -707,8 +707,8 @@ def create_container():
                         except lxc.ContainerAlreadyExists:
                             flash(u'The Container %s is already created!'
                                   % name, 'error')
-                        except subprocess.CalledProcessError:
-                            flash(u'Error creating container %s' % name, 'error')
+                        except subprocess.CalledProcessError as e:
+                            flash(u'Error creating container %s: %s' % (name, e.output), 'error')
 
                 elif storage_method == 'zfs':
                     zfs = request.form['zpoolname']
@@ -721,8 +721,8 @@ def create_container():
                                 flash(u'Failed to create %s!' % name, 'error')
                         except lxc.ContainerAlreadyExists:
                             flash(u'The Container %s is already created!' % name, 'error')
-                        except subprocess.CalledProcessError:
-                            flash(u'Error creating container %s' % name, 'error')
+                        except subprocess.CalledProcessError as e:
+                            flash(u'Error creating container %s: %s' % (name, e.output), 'error')
 
                 elif storage_method == 'lvm':
                     lvname = request.form['lvname']
@@ -751,8 +751,8 @@ def create_container():
                     except lxc.ContainerAlreadyExists:
                         flash(u'The container/logical volume %s is '
                               'already created!' % name, 'error')
-                    except subprocess.CalledProcessError:
-                        flash(u'Error creating container %s' % name, 'error')
+                    except subprocess.CalledProcessError as e:
+                        flash(u'Error creating container %s: %s' % (name, e.output), 'error')
 
                 else:
                     flash(u'Missing parameters to create container!', 'error')

--- a/lwp.py
+++ b/lwp.py
@@ -592,65 +592,60 @@ def action():
 
             if action == 'start':
                 try:
-                    if lxc.start(name) == 0:
-                        # Fix bug : "the container is randomly not
-                        #            displayed in overview list after a boot"
-                        time.sleep(1)
-                        flash(u'Container %s started successfully!' % name,
-                              'success')
-                    else:
-                        flash(u'Unable to start %s!' % name, 'error')
+                    lxc.start(name)
+                    # Fix bug : "the container is randomly not
+                    #            displayed in overview list after a boot"
+                    time.sleep(1)
+                    flash(u'Container %s started successfully!' % name, 'success')
                 except lxc.ContainerAlreadyRunning:
                     flash(u'Container %s is already running!' % name, 'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'Unable to start %s: %s' % (name, e.output), 'error')
             elif action == 'stop':
                 try:
-                    if lxc.stop(name) == 0:
-                        flash(u'Container %s stopped successfully!' % name,
-                              'success')
-                    else:
-                        flash(u'Unable to stop %s!' % name, 'error')
+                    lxc.stop(name)
+                    flash(u'Container %s stopped successfully!' % name, 'success')
                 except lxc.ContainerNotRunning:
                     flash(u'Container %s is already stopped!' % name, 'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'Unable to stop %s: %s' % (name, e.output), 'error')
             elif action == 'freeze':
                 try:
-                    if lxc.freeze(name) == 0:
-                        flash(u'Container %s frozen successfully!' % name,
-                              'success')
-                    else:
-                        flash(u'Unable to freeze %s!' % name, 'error')
+                    lxc.freeze(name)
+                    flash(u'Container %s frozen successfully!' % name, 'success')
                 except lxc.ContainerNotRunning:
                     flash(u'Container %s not running!' % name, 'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'Unable to freeze %s: %s' % (name, e.output), 'error')
             elif action == 'unfreeze':
                 try:
-                    if lxc.unfreeze(name) == 0:
-                        flash(u'Container %s unfrozen successfully!' % name,
-                              'success')
-                    else:
-                        flash(u'Unable to unfeeze %s!' % name, 'error')
+                    lxc.unfreeze(name)
+                    flash(u'Container %s unfrozen successfully!' % name, 'success')
                 except lxc.ContainerNotRunning:
                     flash(u'Container %s not frozen!' % name, 'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'Unable to unfeeze %s: %s' % (name, e.output), 'error')
+
             elif action == 'destroy':
                 if session['su'] != 'Yes':
                     return abort(403)
                 try:
-                    if lxc.destroy(name) == 0:
-                        flash(u'Container %s destroyed successfully!' % name,
-                              'success')
-                    else:
-                        flash(u'Unable to destroy %s!' % name, 'error')
+                    lxc.destroy(name):
+                    flash(u'Container %s destroyed successfully!' % name, 'success')
                 except lxc.ContainerDoesntExists:
                     flash(u'The Container %s does not exists!' % name, 'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'Unable to destroy %s: %s' % (name, e.output), 'error')
             elif action == 'reboot' and name == 'host':
                 if session['su'] != 'Yes':
                     return abort(403)
                 msg = '\v*** LXC Web Panel *** \
                         \nReboot from web panel'
                 try:
-                    subprocess.check_call('/sbin/shutdown -r now \'%s\'' % msg,
-                                          shell=True)
+                    lxc._run('/sbin/shutdown -r now \'%s\'' % msg)
                     flash(u'System will now restart!', 'success')
-                except:
-                    flash(u'System error!', 'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'System error: %s' % e.output, 'error')
         try:
             if request.args['from'] == 'edit':
                 return redirect('../%s/edit' % name)
@@ -679,12 +674,8 @@ def create_container():
 
                 if storage_method == 'default':
                     try:
-                        if lxc.create(name, template=template,
-                                      xargs=command) == 0:
-                            flash(u'Container %s created successfully!' % name,
-                                  'success')
-                        else:
-                            flash(u'Failed to create %s!' % name, 'error')
+                        lxc.create(name, template=template, xargs=command)
+                        flash(u'Container %s created successfully!' % name, 'success')
                     except lxc.ContainerAlreadyExists:
                         flash(u'The Container %s is already created!' % name,
                               'error')
@@ -697,13 +688,11 @@ def create_container():
                     if re.match('^/[a-zA-Z0-9_/-]+$', directory) and \
                             directory != '':
                         try:
-                            if lxc.create(name, template=template,
-                                          storage='dir --dir %s' % directory,
-                                          xargs=command) == 0:
-                                flash(u'Container %s created successfully!'
-                                      % name, 'success')
-                            else:
-                                flash(u'Failed to create %s!' % name, 'error')
+                            lxc.create(name, template=template,
+                                       storage='dir --dir %s' % directory,
+                                       xargs=command)
+                            flash(u'Container %s created successfully!'
+                                  % name, 'success')
                         except lxc.ContainerAlreadyExists:
                             flash(u'The Container %s is already created!'
                                   % name, 'error')
@@ -715,10 +704,8 @@ def create_container():
 
                     if re.match('^[a-zA-Z0-9_/-]+$', zfs) and zfs != '':
                         try:
-                            if lxc.create(name, template=template, storage='zfs --zfsroot %s' % zfs, xargs=command) == 0:
-                                flash(u'Container %s created successfully!' % name, 'success')
-                            else:
-                                flash(u'Failed to create %s!' % name, 'error')
+                            lxc.create(name, template=template, storage='zfs --zfsroot %s' % zfs, xargs=command)
+                            flash(u'Container %s created successfully!' % name, 'success')
                         except lxc.ContainerAlreadyExists:
                             flash(u'The Container %s is already created!' % name, 'error')
                         except subprocess.CalledProcessError as e:
@@ -741,13 +728,8 @@ def create_container():
                         storage_options += ' --fssize %s' % fssize
 
                     try:
-                        if lxc.create(name, template=template,
-                                      storage=storage_options,
-                                      xargs=command) == 0:
-                            flash(u'Container %s created successfully!' % name,
-                                  'success')
-                        else:
-                            flash(u'Failed to create %s!' % name, 'error')
+                        lxc.create(name, template=template, storage=storage_options, xargs=command)
+                        flash(u'Container %s created successfully!' % name, 'success')
                     except lxc.ContainerAlreadyExists:
                         flash(u'The container/logical volume %s is '
                               'already created!' % name, 'error')
@@ -790,18 +772,12 @@ def clone_container():
                 out = None
 
                 try:
-                    out = lxc.clone(orig=orig, new=name, snapshot=snapshot)
+                    lxc.clone(orig=orig, new=name, snapshot=snapshot)
+                    flash(u'Container %s cloned into %s successfully!' % (orig, name), 'success')
                 except lxc.ContainerAlreadyExists:
                     flash(u'The Container %s already exists!' % name, 'error')
-                except subprocess.CalledProcessError:
-                    flash(u'Can\'t snapshot a directory', 'error')
-
-                if out and out == 0:
-                    flash(u'Container %s cloned into %s successfully!'
-                          % (orig, name), 'success')
-                elif out and out != 0:
-                    flash(u'Failed to clone %s into %s!' % (orig, name),
-                          'error')
+                except subprocess.CalledProcessError as e:
+                    flash(u'Failed to clone %s into %s: %s' % (orig, name, e.output), 'error')
 
             else:
                 if name == '':

--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -30,25 +30,11 @@ import subprocess
 import os
 
 
-def _run(cmd, output=False):
+def _run(cmd):
     '''
     To run command easier
     '''
-
-    if output:
-        try:
-            out = subprocess.check_output('{}'.format(cmd), shell=True,
-                                          universal_newlines=True)
-        except subprocess.CalledProcessError:
-            out = False
-
-        return out
-
-    # ignore output if command returned 0,
-    # otherwise CalledProcessError will have the return code in the returncode attribute and any output in the output attribute
-    subprocess.check_output('{}'.format(cmd), shell=True,
-                             universal_newlines=True)  # returns 0 for True
-    return 0
+    return subprocess.check_output('{}'.format(cmd), shell=True, universal_newlines=True)
 
 
 class ContainerAlreadyExists(Exception):
@@ -72,11 +58,7 @@ def exists(container):
     Check if container exists
     '''
 
-    if container in ls():
-        return True
-
-    return False
-
+    return (container in ls())
 
 def create(container, template='ubuntu', storage=None, xargs=None):
     '''
@@ -126,8 +108,7 @@ def info(container):
         raise ContainerDoesntExists(
             'Container {} does not exist!'.format(container))
 
-    output = _run('lxc-info -qn {}|grep -i "State\|PID"'.format(container),
-                  output=True).splitlines()
+    output = _run('lxc-info -qn {}|grep -i "State\|PID"'.format(container)).splitlines()
 
     state = output[0].split()[1]
 
@@ -278,7 +259,7 @@ def checkconfig():
     Returns the output of lxc-checkconfig (colors cleared)
     '''
 
-    out = _run('lxc-checkconfig', output=True)
+    out = _run('lxc-checkconfig')
 
     if out:
         return out.replace('[1;32m', '').replace('[1;33m', '') \

--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -120,6 +120,14 @@ def info(container):
     return {'state': state,
             'pid': pid}
 
+def ip_address(container, assume_running=False):
+    try:
+        if assume_running or (info(container)['state'] == 'RUNNING'):
+            return _run('lxc-info -n %s -iH' % container)
+    except:
+        pass
+    return '' 
+
 
 def ls():
     '''

--- a/lxclite/__init__.py
+++ b/lxclite/__init__.py
@@ -44,8 +44,11 @@ def _run(cmd, output=False):
 
         return out
 
-    return subprocess.check_call('{}'.format(cmd), shell=True,
-                                 universal_newlines=True)  # returns 0 for True
+    # ignore output if command returned 0,
+    # otherwise CalledProcessError will have the return code in the returncode attribute and any output in the output attribute
+    subprocess.check_output('{}'.format(cmd), shell=True,
+                             universal_newlines=True)  # returns 0 for True
+    return 0
 
 
 class ContainerAlreadyExists(Exception):


### PR DESCRIPTION
Missing formatting in the flash() call on container create error, throws "Internal Server Error"
As well changed _run() helper method, so when subprocess throws CalledProcessError exception, the ouput is contained in the output attribute.
It took me a while to figure out why can not create a centos image on ubuntu, it was a missing yum command that lxc-create was reporting the output.